### PR TITLE
Improve article fetch retries and error handling

### DIFF
--- a/core/news_store.py
+++ b/core/news_store.py
@@ -203,7 +203,10 @@ def _enrich_content_only(arts: List[Dict], content_delay: float, stats: Dict) ->
             if status_flag == "retry" and isinstance(retry_at, (int, float)):
                 if retry_at > now():
                     continue
-            result = fetch_fulltext(u)
+            try:
+                result = fetch_fulltext(u, return_meta=True)
+            except TypeError:
+                result = fetch_fulltext(u)
             if isinstance(result, tuple) and len(result) == 2 and isinstance(result[1], dict):
                 text, meta = result
             else:


### PR DESCRIPTION
## Summary
- add retry-aware metadata to `fetch_fulltext`, including HTTP status handling and exponential backoff
- teach news content enrichment to distinguish transient vs permanent failures and schedule retries
- reuse the shared enrichment path during provider downloads to leverage the new retry semantics

## Testing
- python -m compileall core/article_scraper.py core/news_store.py

------
https://chatgpt.com/codex/tasks/task_e_68cea87131a883299cf5eb4813f83c37