### PR TITLE
feat: improve article content diagnostics

### DIFF
--- a/core/article_scraper.py
+++ b/core/article_scraper.py
@@ -3,6 +3,7 @@ import re, html, time
 from urllib.parse import urljoin, urlparse
 from html.parser import HTMLParser
 import requests
+from typing import Dict, Tuple
 
 DEFAULT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124 Safari/537.36"
 
@@ -46,34 +47,66 @@ class _TextCollector(HTMLParser):
         txt = re.sub(r"\n{3,}", "\n\n", txt)
         return txt.strip()
 
-def fetch_fulltext(url: str, timeout: int = 12, ua: str = None, max_len: int = 20000) -> str:
+def fetch_fulltext(url: str, timeout: int = 12, ua: str = None, max_len: int = 20000) -> Tuple[str, Dict[str, str]]:
     """Best-effort article text extraction with stdlib only.
-       Returns plain text, or "" if not parseable.
+       Returns ``(plain_text, diagnostics)`` where ``plain_text`` is empty when extraction fails.
     """
     if not url:
-        return ""
-    headers = {"User-Agent": ua or DEFAULT_UA, "Accept":"text/html,application/xhtml+xml"}
+        return "", {"phase": "pre", "error": "empty_url"}
+
+    headers = {"User-Agent": ua or DEFAULT_UA, "Accept": "text/html,application/xhtml+xml"}
+    start_ts = time.time()
+
     try:
         r = requests.get(url, headers=headers, timeout=timeout, allow_redirects=True)
-    except Exception:
-        return ""
-    ctype = (r.headers.get("Content-Type","").split(";")[0] or "").lower()
+    except Exception as e:
+        elapsed = int((time.time() - start_ts) * 1000)
+        return "", {"phase": "request", "error": type(e).__name__, "message": str(e), "elapsed_ms": str(elapsed)}
+
+    elapsed = int((time.time() - start_ts) * 1000)
+    diagnostics: Dict[str, str] = {
+        "phase": "request",
+        "status": str(r.status_code),
+        "elapsed_ms": str(elapsed),
+    }
+
+    ctype = (r.headers.get("Content-Type", "").split(";")[0] or "").lower()
+    diagnostics["content_type"] = ctype
+
+    if r.status_code >= 400:
+        diagnostics.update({"phase": "http_error", "error": f"status_{r.status_code}"})
+        return "", diagnostics
+
     if "text/html" not in ctype and "application/xhtml" not in ctype:
-        return ""
+        diagnostics.update({"phase": "content_type", "error": "non_html"})
+        return "", diagnostics
+
     html_str = r.text
     # Heuristic pre-trim: drop nav/header/footer blocks crudely
     html_str = re.sub(r"<(nav|footer|aside|script|style|noscript)[\\s\\S]*?</\\1>", " ", html_str, flags=re.I)
+
     # Simple parse
     p = _TextCollector()
+    parse_error = None
     try:
         p.feed(html_str)
-    except Exception:
+    except Exception as e:
         # Some pages break the parser; still try to emit what we have
-        pass
-    txt = p.text()
+        parse_error = e
+
+    txt = (p.text() or "").strip()
     if not txt:
-        return ""
-    txt = txt.strip()
+        diagnostics.update({"phase": "extract", "error": "empty_text"})
+        if parse_error:
+            diagnostics["parser_error"] = f"{type(parse_error).__name__}: {parse_error}"
+        return "", diagnostics
+
     if len(txt) > max_len:
         txt = txt[:max_len] + " ..."
-    return txt
+        diagnostics["truncated"] = "1"
+
+    diagnostics.update({"phase": "success", "length": str(len(txt))})
+    if parse_error:
+        diagnostics["parser_warning"] = f"{type(parse_error).__name__}: {parse_error}"
+
+    return txt, diagnostics


### PR DESCRIPTION
## Summary
- update `fetch_fulltext` to return both article text and diagnostic metadata that records HTTP status, content-type issues, parser warnings, and other failure details
- persist the diagnostic string on articles that fail enrichment, aggregate content error types in stats, and keep those counts when enriching provider responses
- expose the aggregated content error types on progress events so operators can monitor common failure modes while runs execute

## Testing
- python -m compileall core

------
https://chatgpt.com/codex/tasks/task_e_68cea87b6f508329bf023b795d7c9490