### PR TITLE
Handle invalid embeddings in memory retrieval

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -37,15 +37,54 @@ class MemoryBank:
         return math.exp(-delta/max(1,Q))
     def retrieve(self, query_text: str, on_date: str, cfg):
         q = self._embed([query_text])[0]
+        needs_save = False
         def score_layer(items, Q, alpha, k):
+            nonlocal needs_save
             if not items or k<=0: return []
-            M = np.array([it.get("embedding",[]) for it in items], dtype=float)
+            valid_items = []
+            vectors = []
+            expected_dim = None
+            for it in items:
+                emb = it.get("embedding")
+                if not emb:
+                    text = it.get("text", "").strip()
+                    if text:
+                        try:
+                            regenerated = self._embed([text])[0]
+                        except Exception:
+                            regenerated = None
+                        if regenerated is not None:
+                            try:
+                                emb_arr = np.asarray(regenerated, dtype=float)
+                            except (TypeError, ValueError):
+                                emb_arr = None
+                            if emb_arr is not None and emb_arr.ndim == 1 and emb_arr.size > 0:
+                                emb = emb_arr.tolist()
+                                it["embedding"] = emb
+                                needs_save = True
+                if emb is None:
+                    continue
+                try:
+                    emb_arr = np.asarray(emb, dtype=float)
+                except (TypeError, ValueError):
+                    continue
+                if emb_arr.ndim != 1 or emb_arr.size == 0:
+                    continue
+                if expected_dim is None:
+                    expected_dim = emb_arr.size
+                elif emb_arr.size != expected_dim:
+                    continue
+                vectors.append(emb_arr)
+                valid_items.append(it)
+            if not valid_items:
+                return []
+            M = np.vstack(vectors)
             norms = np.linalg.norm(M, axis=1, keepdims=True); norms[norms==0]=1.0; M = M / norms
             qv = np.array(q, dtype=float); qv = qv/(np.linalg.norm(qv)+1e-9)
             rel = (M @ qv).tolist()
-            imps = [it.get("importance",0.0) for it in items]; max_imp = max(1e-6, max(imps))
+            imps = [it.get("importance",0.0) for it in valid_items]; max_imp = max(1e-6, max(imps))
             scored = []
-            for it, r, imp in zip(items, rel, imps):
+            for it, r, imp in zip(valid_items, rel, imps):
                 rec = self._recency_weight(it.get("seen_date","1970-01-01"), on_date, Q)
                 gamma = r + (imp/max_imp)*alpha + rec; scored.append((gamma, it))
             scored.sort(key=lambda x: (x[0], x[1].get("id","")), reverse=True)
@@ -53,5 +92,6 @@ class MemoryBank:
         S = score_layer(self.layers["shallow"], cfg.Q_shallow, cfg.alpha_shallow, cfg.k_shallow)
         I = score_layer(self.layers["intermediate"], cfg.Q_intermediate, cfg.alpha_intermediate, cfg.k_intermediate)
         D = score_layer(self.layers["deep"], cfg.Q_deep, cfg.alpha_deep, cfg.k_deep)
+        if needs_save: self.save()
         for it in S+I+D: it["access"] = int(it.get("access",0))+1
         return S,I,D


### PR DESCRIPTION
## Summary
- skip memory entries with invalid embeddings and normalize only consistent vectors during retrieval
- regenerate missing embeddings from stored text when available and persist refreshed data

## Testing
- python -m compileall core/memory.py

------
https://chatgpt.com/codex/tasks/task_e_68cebce14cdc832998dcd63662f05527