### PR TITLE
Respect skip_existing flag when re-downloading news

### DIFF
--- a/core/news_store.py
+++ b/core/news_store.py
@@ -374,8 +374,8 @@ def download_range(symbol: str, start_iso: str, end_iso: str, K: int = 5, base_d
             enough_count = usable_count >= K
             need_content = bool(full_content) and any((not _has_content(a)) for a in usable_existing[:K])
 
-            # 1) Full skip
-            if pre_arts and enough_count and not need_content:
+            # 1) Full skip (optional via skip_existing flag)
+            if skip_existing and pre_arts and enough_count and not need_content:
                 stats["skipped_existing"] += 1
                 cleaned = usable_existing
                 provider_label = pre_provider or "local"


### PR DESCRIPTION
## Summary
- gate the cached-day short-circuit in `download_range` behind the `skip_existing` option
- ensure progress bookkeeping continues unchanged while allowing forced re-downloads

## Testing
- python -m compileall core/news_store.py

------
https://chatgpt.com/codex/tasks/task_e_68cec4fb3cc48329b514d663e2900fcd