### PR TITLE
Refactor daily context preparation into shared helper

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -1,0 +1,102 @@
+"""Shared daily pipeline utilities for training/backtest flows."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Dict, List, Sequence
+
+from .capsules import build_capsule
+from .news_fetcher import fetch_news_with_reason
+
+
+@dataclass
+class PromptBundle:
+    """Container for a system/user prompt pair."""
+
+    system: Dict[str, Any]
+    user: Dict[str, Any]
+
+    def as_messages(self) -> List[Dict[str, Any]]:
+        return [self.system, self.user]
+
+
+@dataclass
+class DailyContext:
+    """Structured data produced for a trading day."""
+
+    capsule: Dict[str, Any]
+    provider_label: str
+    news_reason: str
+    articles: Sequence[Dict[str, Any]]
+    factor_prompt: PromptBundle
+    policy_prompt: PromptBundle
+
+
+@lru_cache(maxsize=None)
+def _load_prompt(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _prov_label(reason: str) -> str:
+    parts = (reason or "").split(":")
+    if not parts:
+        return "unknown"
+    if parts[0] == "cache" and len(parts) > 1:
+        return f"cache->{parts[1]}"
+    return parts[0]
+
+
+def _build_regime(price_row: Dict[str, Any]) -> Dict[str, Any]:
+    price_val = price_row.get("price", price_row.get("close", 1.0))
+    try:
+        price = float(price_val)
+    except Exception:
+        price = 1.0
+    price = price if price != 0 else 1.0
+    atr = float(price_row.get("atr", 0.0) or 0.0)
+    trend_up = 1 if price_row.get("trend_up", 0) == 1 else 0
+    return {
+        "market": "up" if trend_up == 1 else "down_or_sideways",
+        "vol_bucket": "high" if (atr / max(1.0, price)) > 0.02 else "low",
+    }
+
+
+def prepare_daily_context(cfg, date_iso: str, price_row: Dict[str, Any]) -> DailyContext:
+    """Fetch headlines, build a capsule and prepare prompts for a trading day."""
+
+    articles: Sequence[Dict[str, Any]]
+    reason: str
+    provider_used = "Off"
+
+    if getattr(cfg, "K_news_per_day", 0) > 0 and getattr(cfg, "news_source", "Off") != "Off":
+        articles, reason = fetch_news_with_reason(cfg.symbol, date_iso, cfg.K_news_per_day)
+        provider_used = _prov_label(reason)
+    else:
+        articles, reason = [], "K_news_per_day=0"
+
+    regime = _build_regime(price_row)
+    article_list = list(articles)
+    capsule = build_capsule(date_iso, cfg.symbol, price_row, article_list, [], regime)
+    capsule["headlines_source"] = provider_used
+
+    factor_prompt = PromptBundle(
+        system={"role": "system", "content": _load_prompt(os.path.join("prompts", "factor_head.txt"))},
+        user={"role": "user", "content": json.dumps(capsule, sort_keys=True)},
+    )
+    policy_prompt = PromptBundle(
+        system={"role": "system", "content": _load_prompt(os.path.join("prompts", "policy_head.txt"))},
+        user={"role": "user", "content": json.dumps({"capsule": capsule})},
+    )
+
+    return DailyContext(
+        capsule=capsule,
+        provider_label=provider_used,
+        news_reason=reason,
+        articles=article_list,
+        factor_prompt=factor_prompt,
+        policy_prompt=policy_prompt,
+    )

--- a/core/train.py
+++ b/core/train.py
@@ -1,14 +1,14 @@
 
-from datetime import datetime, timedelta
-import os, json, pandas as pd
+import json
+import pandas as pd
 from .logger import get_logger
 from .config import load_config
 from .data_fetcher import get_daily_bars
 from .indicators import add_indicators
-from .news_fetcher import fetch_news_with_reason
 from .memory import MemoryBank
-from .capsules import build_capsule, capsule_path
+from .capsules import capsule_path
 from .llm import chat_json
+from .pipeline import prepare_daily_context
 
 log = get_logger()
 
@@ -30,14 +30,6 @@ def _coerce_factor_numbers(factor: dict) -> dict:
     for k in keys:
         factor[k] = _to_float(factor.get(k, 0.0), 0.0)
     return factor
-
-def _prov_label(reason: str) -> str:
-    parts = (reason or "").split(":")
-    if not parts:
-        return "unknown"
-    if parts[0] == "cache" and len(parts) > 1:
-        return f"cache->{parts[1]}"
-    return parts[0]
 
 def run_training(config_path="config.json", on_event=None):
     def emit(evt):
@@ -66,30 +58,19 @@ def run_training(config_path="config.json", on_event=None):
             continue
         pr = row.iloc[0].to_dict()
 
-        arts, reason = ([], "K_news_per_day=0")
-        provider_used = "Off"
-        if cfg.K_news_per_day > 0 and cfg.news_source != "Off":
-            arts, reason = fetch_news_with_reason(cfg.symbol, d_iso, cfg.K_news_per_day)
-            provider_used = _prov_label(reason)
+        ctx = prepare_daily_context(cfg, d_iso, pr)
 
+        arts = list(ctx.articles)
         if not arts:
-            emit({"type":"info","message":f"[{d_iso}] Sin noticias. Motivo: {reason}"})
+            emit({"type":"info","message":f"[{d_iso}] Sin noticias. Motivo: {ctx.news_reason}"})
             bank.add_item("shallow", f"{cfg.symbol} daily capsule {d_iso}", {"date": d_iso}, base_importance=5.0, seen_date=d_iso)
         else:
-            emit({"type":"info","message":f"[{d_iso}] {len(arts)} titulares de {provider_used} (reason={reason})"})
+            emit({"type":"info","message":f"[{d_iso}] {len(arts)} titulares de {ctx.provider_label} (reason={ctx.news_reason})"})
 
-        regime = {
-            "market": "up" if pr.get("trend_up",0)==1 else "down_or_sideways",
-            "vol_bucket": "high" if float(pr.get("atr",0))/max(1.0,float(pr.get("price",1.0))) > 0.02 else "low"
-        }
-
-        cap = build_capsule(d_iso, cfg.symbol, pr, arts, [], regime)
-        cap["headlines_source"] = provider_used  # embed provider in capsule for UI debugging
+        cap = ctx.capsule
         emit({"type":"capsule","date":d_iso,"capsule":cap})
 
-        sys = {"role":"system","content": open("prompts/factor_head.txt","r",encoding="utf-8").read()}
-        usr = {"role":"user","content": json.dumps(cap, sort_keys=True)}
-        factor = chat_json([sys, usr], model=cfg.decision_model, max_tokens=120)
+        factor = chat_json(ctx.factor_prompt.as_messages(), model=cfg.decision_model, max_tokens=120)
 
         factor = _coerce_factor_numbers(factor)
         emit({"type":"factor","date":d_iso,"factor":factor})


### PR DESCRIPTION
## Summary
- add a shared `prepare_daily_context` helper to centralize news fetching, capsule creation, and prompt assembly
- refactor training and backtest flows to consume the shared context while keeping their loop-specific logic intact

## Testing
- python -m compileall core/pipeline.py core/train.py core/backtest.py

------
https://chatgpt.com/codex/tasks/task_e_68cec616c6348329aec8fd2faba78573