### PR TITLE
Integrate memory retrieval into daily context pipeline

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,7 @@
   "K_news_per_day": 3,
   "embedding_model": "text-embedding-3-small",
   "decision_model": "gpt-4o-mini",
+  "memory_path": "data/memory_bank.json",
   "retrieval": {
     "k_shallow": 3,
     "k_intermediate": 0,

--- a/core/config.py
+++ b/core/config.py
@@ -39,6 +39,7 @@ class Config:
     K_news_per_day: int = 5
     embedding_model: str = "text-embedding-3-small"
     decision_model: str = "gpt-4o-mini"
+    memory_path: str = "data/memory_bank.json"
     retrieval: RetrievalCfg = field(default_factory=RetrievalCfg)
     risk: RiskCfg = field(default_factory=RiskCfg)
 
@@ -58,6 +59,7 @@ def load_config(path: str) -> Config:
         K_news_per_day = int(raw.get("K_news_per_day", 5)),
         embedding_model = raw.get("embedding_model","text-embedding-3-small"),
         decision_model  = raw.get("decision_model","gpt-4o-mini"),
+        memory_path = raw.get("memory_path", "data/memory_bank.json"),
         retrieval = RetrievalCfg(**raw.get("retrieval", {})),
         risk = RiskCfg(**raw.get("risk", {})),
     )

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from .capsules import build_capsule
+from .memory import MemoryBank
 from .news_fetcher import fetch_news_with_reason
 
 
@@ -33,6 +34,8 @@ class DailyContext:
     articles: Sequence[Dict[str, Any]]
     factor_prompt: PromptBundle
     policy_prompt: PromptBundle
+    memory_retrieval: Dict[str, Sequence[Dict[str, Any]]] = field(default_factory=dict)
+    memory_highlights: Sequence[Dict[str, Any]] = field(default_factory=list)
 
 
 @lru_cache(maxsize=None)
@@ -65,7 +68,58 @@ def _build_regime(price_row: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def prepare_daily_context(cfg, date_iso: str, price_row: Dict[str, Any]) -> DailyContext:
+def _should_use_memory(retrieval_cfg: Any) -> bool:
+    if retrieval_cfg is None:
+        return False
+    keys = ("k_shallow", "k_intermediate", "k_deep")
+    for key in keys:
+        if getattr(retrieval_cfg, key, 0) > 0:
+            return True
+    return False
+
+
+_MEMORY_CACHE: Dict[Tuple[str, str], MemoryBank] = {}
+
+
+def _resolve_memory_bank(cfg, memory_bank: Optional[MemoryBank]) -> Optional[MemoryBank]:
+    if memory_bank is not None:
+        return memory_bank
+    path = getattr(cfg, "memory_path", None)
+    if not path:
+        return None
+    emb_model = getattr(cfg, "embedding_model", "text-embedding-3-small")
+    key = (path, emb_model)
+    bank = _MEMORY_CACHE.get(key)
+    if bank is None:
+        bank = MemoryBank(path=path, emb_model=emb_model)
+        _MEMORY_CACHE[key] = bank
+    return bank
+
+
+def _sanitize_memory_items(layer: str, items: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    sanitized: List[Dict[str, Any]] = []
+    for it in items or []:
+        sanitized.append(
+            {
+                "layer": layer,
+                "id": it.get("id"),
+                "text": it.get("text", ""),
+                "meta": it.get("meta", {}) or {},
+                "importance": float(it.get("importance", 0.0) or 0.0),
+                "seen_date": it.get("seen_date"),
+                "access": int(it.get("access", 0) or 0),
+            }
+        )
+    return sanitized
+
+
+def prepare_daily_context(
+    cfg,
+    date_iso: str,
+    price_row: Dict[str, Any],
+    *,
+    memory_bank: Optional[MemoryBank] = None,
+) -> DailyContext:
     """Fetch headlines, build a capsule and prepare prompts for a trading day."""
 
     articles: Sequence[Dict[str, Any]]
@@ -83,13 +137,50 @@ def prepare_daily_context(cfg, date_iso: str, price_row: Dict[str, Any]) -> Dail
     capsule = build_capsule(date_iso, cfg.symbol, price_row, article_list, [], regime)
     capsule["headlines_source"] = provider_used
 
+    retrieval_cfg = getattr(cfg, "retrieval", None)
+    memory_layers: Dict[str, Sequence[Dict[str, Any]]] = {
+        "shallow": [],
+        "intermediate": [],
+        "deep": [],
+    }
+    memory_highlights: List[Dict[str, Any]] = []
+
+    if _should_use_memory(retrieval_cfg):
+        bank = _resolve_memory_bank(cfg, memory_bank)
+        if bank is not None:
+            query = json.dumps(capsule, sort_keys=True)
+            try:
+                shallow, intermediate, deep = bank.retrieve(query, date_iso, retrieval_cfg)
+            except Exception:
+                shallow, intermediate, deep = [], [], []
+            memory_layers = {
+                "shallow": _sanitize_memory_items("shallow", shallow),
+                "intermediate": _sanitize_memory_items("intermediate", intermediate),
+                "deep": _sanitize_memory_items("deep", deep),
+            }
+            for layer in ("shallow", "intermediate", "deep"):
+                for item in memory_layers[layer]:
+                    memory_highlights.append(
+                        {
+                            "layer": layer,
+                            "text": item.get("text", ""),
+                            "meta": item.get("meta", {}),
+                            "seen_date": item.get("seen_date"),
+                            "importance": item.get("importance", 0.0),
+                        }
+                    )
+
+    factor_payload = dict(capsule)
+    factor_payload["memory_highlights"] = memory_highlights
+    policy_payload = {"capsule": capsule, "memory_highlights": memory_highlights}
+
     factor_prompt = PromptBundle(
         system={"role": "system", "content": _load_prompt(os.path.join("prompts", "factor_head.txt"))},
-        user={"role": "user", "content": json.dumps(capsule, sort_keys=True)},
+        user={"role": "user", "content": json.dumps(factor_payload, sort_keys=True)},
     )
     policy_prompt = PromptBundle(
         system={"role": "system", "content": _load_prompt(os.path.join("prompts", "policy_head.txt"))},
-        user={"role": "user", "content": json.dumps({"capsule": capsule})},
+        user={"role": "user", "content": json.dumps(policy_payload, sort_keys=True)},
     )
 
     return DailyContext(
@@ -97,6 +188,8 @@ def prepare_daily_context(cfg, date_iso: str, price_row: Dict[str, Any]) -> Dail
         provider_label=provider_used,
         news_reason=reason,
         articles=article_list,
+        memory_retrieval=memory_layers,
+        memory_highlights=memory_highlights,
         factor_prompt=factor_prompt,
         policy_prompt=policy_prompt,
     )

--- a/core/train.py
+++ b/core/train.py
@@ -44,7 +44,8 @@ def run_training(config_path="config.json", on_event=None):
     df["date"] = pd.to_datetime(df["date"]).dt.date
     dates = list(df["date"].astype("datetime64[ns]").dt.date)
 
-    bank = MemoryBank("data/memory_bank.json", emb_model=cfg.embedding_model)
+    memory_path = getattr(cfg, "memory_path", None) or "data/memory_bank.json"
+    bank = MemoryBank(memory_path, emb_model=cfg.embedding_model)
     cap_path = capsule_path(cfg.symbol, cfg.train_start, cfg.train_end)
 
     emit({"type":"phase","label":"Training loop","state":"running"})
@@ -58,7 +59,7 @@ def run_training(config_path="config.json", on_event=None):
             continue
         pr = row.iloc[0].to_dict()
 
-        ctx = prepare_daily_context(cfg, d_iso, pr)
+        ctx = prepare_daily_context(cfg, d_iso, pr, memory_bank=bank)
 
         arts = list(ctx.articles)
         if not arts:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_pipeline_memory.py
+++ b/tests/test_pipeline_memory.py
@@ -1,0 +1,69 @@
+import json
+
+from core.config import Config, RetrievalCfg
+from core.memory import MemoryBank
+from core.pipeline import prepare_daily_context
+
+
+def _base_price_row():
+    return {"close": 100.0, "atr": 1.5, "trend_up": 1}
+
+
+def test_prepare_daily_context_memory_section_empty(tmp_path):
+    cfg = Config()
+    cfg.K_news_per_day = 0
+    cfg.news_source = "Off"
+    cfg.memory_path = str(tmp_path / "bank.json")
+    cfg.retrieval = RetrievalCfg(k_shallow=0, k_intermediate=0, k_deep=0)
+
+    ctx = prepare_daily_context(cfg, "2024-01-02", _base_price_row())
+
+    assert ctx.memory_highlights == []
+    assert ctx.memory_retrieval == {"shallow": [], "intermediate": [], "deep": []}
+
+    factor_payload = json.loads(ctx.factor_prompt.user["content"])
+    assert "memory_highlights" in factor_payload
+    assert factor_payload["memory_highlights"] == []
+
+    policy_payload = json.loads(ctx.policy_prompt.user["content"])
+    assert policy_payload["memory_highlights"] == []
+
+
+def test_prepare_daily_context_with_retrieved_memory(tmp_path):
+    cfg = Config()
+    cfg.K_news_per_day = 0
+    cfg.news_source = "Off"
+    cfg.memory_path = str(tmp_path / "bank.json")
+    cfg.retrieval = RetrievalCfg(k_shallow=2, k_intermediate=0, k_deep=0)
+
+    bank = MemoryBank(cfg.memory_path, emb_model=cfg.embedding_model)
+    bank.add_item(
+        "shallow",
+        "AAPL narrative: bullish momentum noted",
+        {"date": "2024-01-01", "tag": "summary"},
+        base_importance=12.0,
+        seen_date="2024-01-01",
+    )
+
+    ctx = prepare_daily_context(
+        cfg,
+        "2024-01-02",
+        _base_price_row(),
+        memory_bank=bank,
+    )
+
+    assert ctx.memory_highlights, "Expected retrieved highlights"
+    assert ctx.memory_retrieval["shallow"], "Shallow layer should include the stored item"
+    assert ctx.memory_retrieval["intermediate"] == []
+    assert ctx.memory_retrieval["deep"] == []
+
+    highlight = ctx.memory_highlights[0]
+    assert highlight["text"].startswith("AAPL narrative")
+    assert highlight["meta"].get("tag") == "summary"
+    assert "embedding" not in highlight
+
+    factor_payload = json.loads(ctx.factor_prompt.user["content"])
+    assert factor_payload["memory_highlights"][0]["text"].startswith("AAPL narrative")
+
+    policy_payload = json.loads(ctx.policy_prompt.user["content"])
+    assert policy_payload["memory_highlights"][0]["text"].startswith("AAPL narrative")


### PR DESCRIPTION
## Summary
- extend the daily context pipeline to surface memory-bank retrievals and inject concise highlights into the factor and policy prompts
- add configuration and runners support for selecting the memory bank path and reusing the same bank during training/backtesting
- cover the new memory-aware prompts with tests that exercise empty and populated banks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceda4a5fc88329ae39b90ee432105e