### PR TITLE
Add portfolio state to policy payload

### DIFF
--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -36,6 +36,7 @@ class DailyContext:
     policy_prompt: PromptBundle
     memory_retrieval: Dict[str, Sequence[Dict[str, Any]]] = field(default_factory=dict)
     memory_highlights: Sequence[Dict[str, Any]] = field(default_factory=list)
+    portfolio_state: Dict[str, Any] = field(default_factory=dict)
 
 
 @lru_cache(maxsize=None)
@@ -119,6 +120,7 @@ def prepare_daily_context(
     price_row: Dict[str, Any],
     *,
     memory_bank: Optional[MemoryBank] = None,
+    portfolio_state: Optional[Dict[str, Any]] = None,
 ) -> DailyContext:
     """Fetch headlines, build a capsule and prepare prompts for a trading day."""
 
@@ -172,7 +174,12 @@ def prepare_daily_context(
 
     factor_payload = dict(capsule)
     factor_payload["memory_highlights"] = memory_highlights
-    policy_payload = {"capsule": capsule, "memory_highlights": memory_highlights}
+    portfolio_payload = dict(portfolio_state or {})
+    policy_payload = {
+        "capsule": capsule,
+        "memory_highlights": memory_highlights,
+        "portfolio_state": portfolio_payload,
+    }
 
     factor_prompt = PromptBundle(
         system={"role": "system", "content": _load_prompt(os.path.join("prompts", "factor_head.txt"))},
@@ -190,6 +197,7 @@ def prepare_daily_context(
         articles=article_list,
         memory_retrieval=memory_layers,
         memory_highlights=memory_highlights,
+        portfolio_state=portfolio_payload,
         factor_prompt=factor_prompt,
         policy_prompt=policy_prompt,
     )

--- a/tests/test_pipeline_memory.py
+++ b/tests/test_pipeline_memory.py
@@ -27,6 +27,8 @@ def test_prepare_daily_context_memory_section_empty(tmp_path):
 
     policy_payload = json.loads(ctx.policy_prompt.user["content"])
     assert policy_payload["memory_highlights"] == []
+    assert policy_payload["portfolio_state"] == {}
+    assert ctx.portfolio_state == {}
 
 
 def test_prepare_daily_context_with_retrieved_memory(tmp_path):
@@ -45,11 +47,23 @@ def test_prepare_daily_context_with_retrieved_memory(tmp_path):
         seen_date="2024-01-01",
     )
 
+    portfolio_state = {
+        "cash": 10000.0,
+        "position": 25,
+        "equity": 12500.0,
+        "max_position": 100,
+        "slippage_bps": 5.0,
+        "commission_per_trade": 1.0,
+        "commission_per_share": 0.01,
+        "risk": {"allow_short": False},
+    }
+
     ctx = prepare_daily_context(
         cfg,
         "2024-01-02",
         _base_price_row(),
         memory_bank=bank,
+        portfolio_state=portfolio_state,
     )
 
     assert ctx.memory_highlights, "Expected retrieved highlights"
@@ -67,3 +81,5 @@ def test_prepare_daily_context_with_retrieved_memory(tmp_path):
 
     policy_payload = json.loads(ctx.policy_prompt.user["content"])
     assert policy_payload["memory_highlights"][0]["text"].startswith("AAPL narrative")
+    assert policy_payload["portfolio_state"] == portfolio_state
+    assert ctx.portfolio_state == portfolio_state


### PR DESCRIPTION
## Summary
- extend the daily context structure to carry an optional portfolio snapshot and expose it in the policy prompt payload
- feed live cash, position, and risk metadata from backtests and provide a flat zeroed portfolio snapshot for training runs
- update pipeline tests to assert the presence of the portfolio block in the encoded policy prompt

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cedf93b5188329af886a4f4ed64acc