### PR TITLE
Track realized returns and log memory feedback

### DIFF
--- a/tests/test_backtest_memory.py
+++ b/tests/test_backtest_memory.py
@@ -1,6 +1,7 @@
 import json
 
 import pandas as pd
+import pytest
 
 from core.backtest import run_backtest
 from core.memory import MemoryBank
@@ -97,11 +98,15 @@ def test_run_backtest_records_factor_memory(tmp_path, monkeypatch):
 
     assert calls["factor"] == len(bars)
     assert calls["policy"] == len(bars)
-    assert len(shallow_items) == len(bars)
+    expected_items = len(bars) + max(len(bars) - 1, 0)
+    assert len(shallow_items) == expected_items
 
     texts = [item.get("text", "") for item in shallow_items]
     assert any(text.startswith("[2023-01-02] mood=0.70 bias=+0.10 nov=0.30 cred=0.60") for text in texts)
-    assert all("factor" in (item.get("meta") or {}) for item in shallow_items)
+    feedback_texts = [text for text in texts if "→" in text]
+    assert len(feedback_texts) == max(len(bars) - 1, 0)
+    factor_items = [item for item in shallow_items if "factor" in (item.get("meta") or {})]
+    assert len(factor_items) == len(bars)
 
 
 def test_run_backtest_skips_factor_memory_when_disabled(tmp_path, monkeypatch):
@@ -139,3 +144,78 @@ def test_run_backtest_skips_factor_memory_when_disabled(tmp_path, monkeypatch):
     assert calls["factor"] == 0
     assert calls["policy"] == len(bars)
     assert shallow_items == []
+
+
+def test_run_backtest_writes_feedback_memory(tmp_path, monkeypatch):
+    memory_path = tmp_path / "bank_feedback.json"
+    config_path = tmp_path / "config_feedback.json"
+    _write_config(
+        config_path,
+        memory_path,
+        {"k_shallow": 2, "k_intermediate": 0, "k_deep": 0},
+    )
+
+    bars = _dummy_bars()
+    monkeypatch.setattr("core.backtest.get_daily_bars", lambda *args, **kwargs: bars.copy())
+
+    def fake_add_indicators(df):
+        out = df.copy()
+        out["atr"] = 1.0
+        out["trend_up"] = 1
+        out["sma200"] = out["close"]
+        out["sma100"] = out["close"]
+        return out
+
+    monkeypatch.setattr("core.backtest.add_indicators", fake_add_indicators)
+    monkeypatch.setattr("core.backtest.plot_equity", lambda *args, **kwargs: "fig_eq")
+    monkeypatch.setattr("core.backtest.plot_drawdown", lambda *args, **kwargs: "fig_dd")
+
+    factor_data = {
+        "mood_score": 0.7,
+        "narrative_bias": 0.1,
+        "novelty": 0.3,
+        "credibility": 0.6,
+        "regime_alignment": 0.5,
+        "confidence": 0.4,
+    }
+
+    policy_sequence = [
+        {"action": "BUY", "target_exposure": 0.2},
+        {"action": "HOLD", "target_exposure": 0.2},
+    ]
+
+    calls = {"factor": 0, "policy": 0}
+
+    def fake_chat(messages, model=None, max_tokens=None):
+        content = messages[0].get("content", "")
+        if "equity narrative analyst" in content:
+            calls["factor"] += 1
+            return dict(factor_data)
+        idx = min(calls["policy"], len(policy_sequence) - 1)
+        resp = dict(policy_sequence[idx])
+        calls["policy"] += 1
+        return resp
+
+    monkeypatch.setattr("core.backtest.chat_json", fake_chat)
+
+    run_backtest(config_path=str(config_path))
+
+    bank = MemoryBank(str(memory_path), emb_model="text-embedding-3-small")
+    shallow_items = bank.layers.get("shallow", [])
+
+    feedback_items = [item for item in shallow_items if "→" in (item.get("text") or "")]
+
+    # Two factor summaries + one feedback entry expected
+    assert len(shallow_items) == 3
+    assert len(feedback_items) == 1
+
+    feedback = feedback_items[0]
+    meta = feedback.get("meta") or {}
+
+    assert feedback["text"].startswith("2023-01-02: BUY 200")
+    assert meta.get("action") == "BUY"
+    assert meta.get("decision_date") == "2023-01-02"
+    assert meta.get("observed_on") == "2023-01-03"
+    assert meta.get("target_exposure") == pytest.approx(0.2)
+    assert meta.get("position") == 200
+    assert meta.get("realized_return") == pytest.approx(0.01, rel=1e-6)


### PR DESCRIPTION
## Summary
- compute next-day realized return and PnL for each backtest decision
- record feedback items in the memory bank with contextual metadata and weighted importance
- add regression coverage ensuring the feedback entries are persisted

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0a6c0f788329a69ada5fb6299855