### PR TITLE
Add configurable initial cash for backtests

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
   "embedding_model": "text-embedding-3-small",
   "decision_model": "gpt-4o-mini",
   "memory_path": "data/memory_bank.json",
+  "initial_cash": 100000.0,
   "retrieval": {
     "k_shallow": 3,
     "k_intermediate": 0,

--- a/core/backtest.py
+++ b/core/backtest.py
@@ -83,8 +83,11 @@ def run_backtest(config_path="config.json", on_event=None, event_rate=10):
     df["date"] = pd.to_datetime(df["date"]).dt.date
     dates = list(df["date"].astype("datetime64[ns]").dt.date)
 
-    cash = 100000.0
+    initial_cash = _to_float(getattr(cfg, "initial_cash", 100000.0), 100000.0)
+    cash = initial_cash
     position = 0
+    bh_shares = 0
+    bh_cash = initial_cash
     eq_series, bh_series, trades = [], [], []
     pending_feedback = None
 
@@ -150,7 +153,8 @@ def run_backtest(config_path="config.json", on_event=None, event_rate=10):
 
         # Buy&Hold benchmark
         if i == 0:
-            bh_shares = int(cash // price); bh_cash = cash - bh_shares * price
+            bh_shares = int(initial_cash // price)
+            bh_cash = initial_cash - bh_shares * price
         equity_bh = bh_shares * price + bh_cash
         bh_series.append((d_iso, equity_bh))
 

--- a/core/config.py
+++ b/core/config.py
@@ -41,6 +41,7 @@ class Config:
     embedding_model: str = "text-embedding-3-small"
     decision_model: str = "gpt-4o-mini"
     memory_path: str = "data/memory_bank.json"
+    initial_cash: float = 100000.0
     retrieval: RetrievalCfg = field(default_factory=RetrievalCfg)
     risk: RiskCfg = field(default_factory=RiskCfg)
 
@@ -52,6 +53,12 @@ def load_config(path: str) -> Config:
         raw = json.load(f)
     symbol = raw.get("symbol", "AAPL")
     memory_path = raw.get("memory_path") or _find_preferred_memory_path(symbol)
+    initial_cash_raw = raw.get("initial_cash", 100000.0)
+    try:
+        initial_cash = float(initial_cash_raw)
+    except (TypeError, ValueError):
+        initial_cash = 100000.0
+
     cfg = Config(
         symbol = symbol,
         train_start = raw.get("train_start", "2022-01-01"),
@@ -63,6 +70,7 @@ def load_config(path: str) -> Config:
         embedding_model = raw.get("embedding_model","text-embedding-3-small"),
         decision_model  = raw.get("decision_model","gpt-4o-mini"),
         memory_path = memory_path,
+        initial_cash = initial_cash,
         retrieval = RetrievalCfg(**raw.get("retrieval", {})),
         risk = RiskCfg(**raw.get("risk", {})),
     )

--- a/tests/test_backtest_memory.py
+++ b/tests/test_backtest_memory.py
@@ -33,6 +33,7 @@ def _write_config(path, memory_path, retrieval):
         "decision_model": "test-model",
         "embedding_model": "text-embedding-3-small",
         "memory_path": str(memory_path),
+        "initial_cash": 100000.0,
         "retrieval": retrieval,
     }
     path.write_text(json.dumps(cfg))

--- a/ui/config_editor.py
+++ b/ui/config_editor.py
@@ -138,6 +138,14 @@ def render_config_tab(cfg_path: str) -> None:
             help="Ruta donde se guarda la memoria entrenada. Si la dejas vacía se utilizará una carpeta dedicada por símbolo para reutilizar sesiones anteriores.",
         )
 
+        initial_cash_input = st.number_input(
+            "Capital inicial",
+            min_value=0.0,
+            value=float(getattr(cfg, "initial_cash", 100000.0)),
+            step=1000.0,
+            help="Monto de efectivo disponible al inicio del backtest. Afecta el tamaño absoluto de las posiciones y el benchmark buy & hold.",
+        )
+
         st.markdown("### Recuperación de memoria")
         k_cols = st.columns(3)
         k_shallow = k_cols[0].number_input(
@@ -319,6 +327,7 @@ def render_config_tab(cfg_path: str) -> None:
         embedding_model=embedding_model.strip() or cfg.embedding_model,
         decision_model=decision_model.strip() or cfg.decision_model,
         memory_path=memory_path_clean,
+        initial_cash=float(initial_cash_input),
         retrieval=RetrievalCfg(
             k_shallow=int(k_shallow),
             k_intermediate=int(k_intermediate),


### PR DESCRIPTION
## Summary
- add an `initial_cash` field to the main Config dataclass and load/save logic
- expose the initial cash setting in the JSON config and Streamlit editor
- use the configured capital when bootstrapping the backtest and update tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf4413b9108329b0028f8ba3dc3235