### PR TITLE
Add periodic contribution handling to backtest

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,8 @@
   "decision_model": "gpt-4o-mini",
   "memory_path": "data/memory_bank.json",
   "initial_cash": 100000.0,
+  "periodic_contribution": 0.0,
+  "contribution_frequency": "none",
   "retrieval": {
     "k_shallow": 3,
     "k_intermediate": 0,

--- a/core/config.py
+++ b/core/config.py
@@ -42,6 +42,8 @@ class Config:
     decision_model: str = "gpt-4o-mini"
     memory_path: str = "data/memory_bank.json"
     initial_cash: float = 100000.0
+    periodic_contribution: float = 0.0
+    contribution_frequency: str = "none"
     retrieval: RetrievalCfg = field(default_factory=RetrievalCfg)
     risk: RiskCfg = field(default_factory=RiskCfg)
 
@@ -54,10 +56,16 @@ def load_config(path: str) -> Config:
     symbol = raw.get("symbol", "AAPL")
     memory_path = raw.get("memory_path") or _find_preferred_memory_path(symbol)
     initial_cash_raw = raw.get("initial_cash", 100000.0)
+    periodic_contribution_raw = raw.get("periodic_contribution", 0.0)
     try:
         initial_cash = float(initial_cash_raw)
     except (TypeError, ValueError):
         initial_cash = 100000.0
+    try:
+        periodic_contribution = max(0.0, float(periodic_contribution_raw))
+    except (TypeError, ValueError):
+        periodic_contribution = 0.0
+    contribution_frequency = str(raw.get("contribution_frequency", "none") or "none").strip().lower()
 
     cfg = Config(
         symbol = symbol,
@@ -71,6 +79,8 @@ def load_config(path: str) -> Config:
         decision_model  = raw.get("decision_model","gpt-4o-mini"),
         memory_path = memory_path,
         initial_cash = initial_cash,
+        periodic_contribution = periodic_contribution,
+        contribution_frequency = contribution_frequency,
         retrieval = RetrievalCfg(**raw.get("retrieval", {})),
         risk = RiskCfg(**raw.get("risk", {})),
     )

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,16 +1,26 @@
 
 import numpy as np, pandas as pd
-def compute_metrics(equity: pd.Series, bh_equity: pd.Series):
+from typing import Optional
+
+
+def compute_metrics(equity: pd.Series, bh_equity: pd.Series, contributions: Optional[pd.Series] = None):
     equity = equity.dropna(); bh_equity = bh_equity.reindex_like(equity).ffill().dropna()
-    if len(equity) < 2: return {}
-    daily = equity.pct_change().fillna(0.0); bh_daily = bh_equity.pct_change().fillna(0.0)
+    if contributions is None:
+        contributions = pd.Series(0.0, index=equity.index)
+    else:
+        contributions = contributions.reindex_like(equity).fillna(0.0)
+    contributions_cum = contributions.cumsum()
+    equity_adj = (equity - contributions_cum).clip(lower=1e-6)
+    bh_adj = (bh_equity - contributions_cum).clip(lower=1e-6)
+    if len(equity_adj) < 2: return {}
+    daily = equity_adj.pct_change().replace([np.inf, -np.inf], 0.0).fillna(0.0); bh_daily = bh_adj.pct_change().replace([np.inf, -np.inf], 0.0).fillna(0.0)
     def sharpe(x): return 0.0 if x.std()==0 else (x.mean()/x.std())*np.sqrt(252)
     def sortino(x):
         downside = x[x<0].std()
         return 0.0 if downside is None or downside==0 else (x.mean()/downside)*np.sqrt(252)
-    cagr = (equity.iloc[-1]/equity.iloc[0])**(252/len(equity)) - 1
-    dd = (equity / equity.cummax() - 1.0).min()
+    cagr = (equity_adj.iloc[-1]/equity_adj.iloc[0])**(252/len(equity_adj)) - 1
+    dd = (equity_adj / equity_adj.cummax() - 1.0).min()
     return {"CAGR": float(cagr), "Sharpe": float(sharpe(daily)), "Sortino": float(sortino(daily)),
             "MaxDrawdown": float(dd), "Volatilidad": float(daily.std()*np.sqrt(252)),
-            "BH_CAGR": float((bh_equity.iloc[-1]/bh_equity.iloc[0])**(252/len(bh_equity)) - 1),
-            "ActiveReturn": float((equity.iloc[-1]/equity.iloc[0]) - (bh_equity.iloc[-1]/bh_equity.iloc[0]))}
+            "BH_CAGR": float((bh_adj.iloc[-1]/bh_adj.iloc[0])**(252/len(bh_adj)) - 1),
+            "ActiveReturn": float((equity_adj.iloc[-1]/equity_adj.iloc[0]) - (bh_adj.iloc[-1]/bh_adj.iloc[0]))}

--- a/ui/config_editor.py
+++ b/ui/config_editor.py
@@ -146,6 +146,37 @@ def render_config_tab(cfg_path: str) -> None:
             help="Monto de efectivo disponible al inicio del backtest. Afecta el tamaño absoluto de las posiciones y el benchmark buy & hold.",
         )
 
+        contrib_cols = st.columns(2)
+        periodic_contribution_input = contrib_cols[0].number_input(
+            "Aporte periódico",
+            min_value=0.0,
+            value=float(getattr(cfg, "periodic_contribution", 0.0)),
+            step=100.0,
+            help="Capital adicional que se ingresará automáticamente según la frecuencia elegida. Déjalo en 0 para desactivar los aportes.",
+        )
+        freq_options = {
+            "Sin aportes": "none",
+            "Mensual (primer día hábil)": "monthly",
+        }
+        freq_labels = list(freq_options.keys())
+        freq_value_to_label = {v: k for k, v in freq_options.items()}
+        current_freq_value = str(getattr(cfg, "contribution_frequency", "none") or "none").strip().lower()
+        current_freq_label = freq_value_to_label.get(current_freq_value, "Sin aportes")
+        try:
+            freq_index = freq_labels.index(current_freq_label)
+        except ValueError:
+            freq_index = 0
+        contribution_frequency_label = contrib_cols[1].selectbox(
+            "Frecuencia de aportes",
+            options=freq_labels,
+            index=freq_index,
+            help="Define cada cuánto se ejecuta el aporte programado. Escoge 'Sin aportes' o establece el monto en 0 para desactivarlos.",
+        )
+        contribution_frequency_value = freq_options[contribution_frequency_label]
+        st.caption(
+            "Los aportes se aplican al inicio del primer día de mercado de cada mes y quedan registrados en el historial de operaciones."
+        )
+
         st.markdown("### Recuperación de memoria")
         k_cols = st.columns(3)
         k_shallow = k_cols[0].number_input(
@@ -328,6 +359,8 @@ def render_config_tab(cfg_path: str) -> None:
         decision_model=decision_model.strip() or cfg.decision_model,
         memory_path=memory_path_clean,
         initial_cash=float(initial_cash_input),
+        periodic_contribution=float(periodic_contribution_input),
+        contribution_frequency=contribution_frequency_value,
         retrieval=RetrievalCfg(
             k_shallow=int(k_shallow),
             k_intermediate=int(k_intermediate),


### PR DESCRIPTION
## Summary
- add periodic contribution settings to the configuration schema and default file
- extend the backtest to execute and record monthly cash contributions while adjusting metrics for external cash flows
- expose contribution controls in the Streamlit config editor with guidance for enabling or disabling the feature

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf466fc6f48329b08dd9833e983114