### PR TITLE
Enforce minimum trade value floor in backtests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,6 @@
 Run `pip install -r requirements.txt` then `streamlit run app.py`.
 Set OPENAI_API_KEY and optionally NEWSAPI_KEY.
 
+When tuning `config.json`, you can set `risk.min_trade_value` to enforce a minimum notional for BUY orders. The backtester will round small allocations up to at least that dollar amount (subject to max position limits and available cash).
+
 The app now bundles [`readability-lxml`](https://github.com/buriy/python-readability) to provide a more robust HTML-to-text extraction fallback for news articles; make sure your environment can compile the underlying lxml dependency when installing.


### PR DESCRIPTION
## Summary
- fetch `risk.min_trade_value` in the backtester and enforce a minimum share floor for BUY orders while honouring max position and cash limits
- extend the backtest memory tests with a regression that verifies minimum notional enforcement and allow overriding the risk config helper
- document the `min_trade_value` option in the README

## Testing
- pytest tests/test_backtest_memory.py

------
https://chatgpt.com/codex/tasks/task_e_68cfb79db7a88329b1465baa01b9d4c0