### PR TITLE
Prevent min trade floor overshoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 Run `pip install -r requirements.txt` then `streamlit run app.py`.
 Set OPENAI_API_KEY and optionally NEWSAPI_KEY.
 
-When tuning `config.json`, you can set `risk.min_trade_value` to enforce a minimum notional for BUY orders. The backtester will round small allocations up to at least that dollar amount (subject to max position limits and available cash).
+When tuning `config.json`, you can set `risk.min_trade_value` to enforce a minimum notional for BUY orders. The backtester will only honor that floor when the requested position change already meets it; otherwise it cancels the trade to avoid overshooting the target (still subject to max position limits and available cash).
 
 The app now bundles [`readability-lxml`](https://github.com/buriy/python-readability) to provide a more robust HTML-to-text extraction fallback for news articles; make sure your environment can compile the underlying lxml dependency when installing.


### PR DESCRIPTION
## Summary
- avoid min trade floor adjustments that would push positions beyond the requested target and log a cancel reason
- update the backtest memory tests to assert cancelled buys and protect short covers from flipping long
- document the revised minimum notional handling in the README risk controls section

## Testing
- pytest tests/test_backtest_memory.py

------
https://chatgpt.com/codex/tasks/task_e_68cfea0008008329a460fcf9ede58ff5